### PR TITLE
Cache dependencies in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,7 @@ install:
 
 script:
   - lein test
+
+cache:
+  directories:
+  - $HOME/.m2


### PR DESCRIPTION
This PR caches Travis deps. This reduces the load on Maven and Clojars. It also makes the builds faster. Time on my module builds as below : 

* Before cache - 55 seconds
* After cache - 44 seconds (No dependencies downloaded from Maven and Clojars) 

Ref : https://docs.travis-ci.com/user/caching/#Arbitrary-directories