### PR TITLE
Add maven dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,9 @@
 language: clojure
 
 install:
-  - wget https://www.foundationdb.org/downloads/5.1.5/ubuntu/installers/foundationdb-clients_5.1.5-1_amd64.deb
-  - wget https://www.foundationdb.org/downloads/5.1.5/ubuntu/installers/foundationdb-server_5.1.5-1_amd64.deb
-  - sudo dpkg -i foundationdb-server_5.1.5-1_amd64.deb foundationdb-clients_5.1.5-1_amd64.deb || true
-  - wget https://www.foundationdb.org/downloads/5.1.7/bindings/java/fdb-java-5.1.7.jar
-  - mvn install:install-file -Dfile=fdb-java-5.1.7.jar -DgroupId=com.apple.foundationdb -DartifactId=fdb-java -Dversion=5.1.7 -Dpackaging=jar
+  - wget https://www.foundationdb.org/downloads/5.2.5/ubuntu/installers/foundationdb-clients_5.2.5-1_amd64.deb
+  - wget https://www.foundationdb.org/downloads/5.2.5/ubuntu/installers/foundationdb-server_5.2.5-1_amd64.deb
+  - sudo dpkg -i foundationdb-clients_5.2.5-1_amd64.deb foundationdb-server_5.2.5-1_amd64.deb
 
 script:
   - lein test

--- a/README.md
+++ b/README.md
@@ -48,17 +48,6 @@ https://vedang.github.io/clj_fdb/
 
 ## Installation
 
-Currently, installing this library from Clojars is broken. This is
-because the FoundationDB Java API Jar is not available for download
-from a central repository like Maven. To use this library, you need to
-download and install it locally. You can do this as follows:
-
-* Download the FoundationDB Java API Jar from here:
-  https://www.foundationdb.org/downloads/5.1.7/bindings/java/fdb-java-5.1.7.jar
-* Install it to your Maven repository as follows:
-```
-$ mvn install:install-file -Dfile=fdb-java-5.1.7.jar -DgroupId=com.apple.foundationdb -DartifactId=fdb-java -Dversion=5.1.7 -Dpackaging=jar
-```
 * Download this library from Github by cloning this project.
 * Run the following command in the top level of the library
 ```

--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,7 @@
   :url "https://vedang.github.io/clj_fdb/"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[com.apple.foundationdb/fdb-java "5.1.7"]
+  :dependencies [[org.foundationdb/fdb-java "5.2.5"]
                  [byte-streams "0.2.3"]]
   :profiles {:dev {:dependencies [[org.clojure/clojure "1.9.0"]
                                   [org.clojure/tools.logging "0.4.1"]]


### PR DESCRIPTION
* The java bindings were released to Maven and hence use them.
* Remove the manual installation instructions in README.md.
* The current java bindings are incompatible with Travis version of FDB and hence upgrade them.

I will add a separate issue to modify docs and code to use API version 520 which is used in the latest docs.

In case of Tuple encoding by default in my library though it makes it easier to use it's not simple and introduces [some complexity](https://github.com/tirkarthi/clj-foundationdb/issues/15) :) It's intentional and a design drawback from my end that I will keep in mind as I design API for my next libraries. So I have added a note on README linking here as an alternative which gives more fine-grained control.

This closes the blocker #1  . Happy releasing 🎉 

Thanks