### PR TITLE
Adding KeySelectors to get-range

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ pom.xml.asc
 /.nrepl-port
 .hgignore
 .hg/
+.dir-locals.el

--- a/deps.edn
+++ b/deps.edn
@@ -1,0 +1,18 @@
+{:paths ["src"]
+
+ :deps
+ {org.foundationdb/fdb-java           {:mvn/version "6.3.23"}}
+
+ :aliases
+ {:dev
+  {:extra-paths ["dev"]
+   :extra-deps  {org.clojure/clojure            {:mvn/version "1.11.1"}
+                 com.lambdaisland/classpath     {:mvn/version "0.0.27"}}}
+
+  :test
+  {:extra-paths ["test"]
+   :extra-deps  {org.clj-commons/byte-streams {:mvn/version "0.3.1"}}}}
+
+ :mvn/repos
+ {"central"        {:url "https://repo1.maven.org/maven2/"}
+  "clojars"        {:url "https://clojars.org/repo"}}}

--- a/deps.edn
+++ b/deps.edn
@@ -6,8 +6,7 @@
  :aliases
  {:dev
   {:extra-paths ["dev"]
-   :extra-deps  {org.clojure/clojure            {:mvn/version "1.11.1"}
-                 com.lambdaisland/classpath     {:mvn/version "0.0.27"}}}
+   :extra-deps  {org.clojure/clojure            {:mvn/version "1.11.1"}}}
 
   :test
   {:extra-paths ["test"]

--- a/project.clj
+++ b/project.clj
@@ -3,10 +3,10 @@
   :url "https://vedang.github.io/clj_fdb/"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.foundationdb/fdb-java "6.3.13"]]
-  :profiles {:dev {:dependencies [[org.clojure/clojure "1.10.3"]
-                                  [org.clojure/tools.logging "1.1.0"]
-                                  [byte-streams "0.2.4"]]
+  :dependencies [[org.foundationdb/fdb-java "6.3.23"]]
+  :profiles {:test {:dependencies [[org.clj-commons/byte-streams "0.3.1"]]}
+             :dev {:dependencies [[org.clojure/clojure "1.11.1"]
+                                  [org.clojure/tools.logging "1.1.0"]]
                    :jvm-opts ["-Dclojure.tools.logging.factory=clojure.tools.logging.impl/slf4j-factory"]
                    :plugins [[lein-codox "0.10.7"]]}}
   :target-path "target/%s"

--- a/src/me/vedang/clj_fdb/core.clj
+++ b/src/me/vedang/clj_fdb/core.clj
@@ -1,7 +1,7 @@
 (ns me.vedang.clj-fdb.core
   (:refer-clojure :exclude [get set range])
   (:require [me.vedang.clj-fdb.impl :as fimpl]
-            [me.vedang.clj-fdb.key-selector :as sut]
+            [me.vedang.clj-fdb.key-selector :as fks]
             [me.vedang.clj-fdb.mutation-type :as fmut]
             [me.vedang.clj-fdb.subspace.subspace :as fsub]
             [me.vedang.clj-fdb.transaction :as ftr]
@@ -115,7 +115,7 @@
 
 (defn- create-range-args [arg1 arg2 {:keys [skip]}]
   (if (instance? KeySelector arg1)
-    [(cond-> arg1 skip (sut/add skip)) arg2]
+    [(cond-> arg1 skip (fks/add skip)) arg2]
     [(range arg1 arg2)]))
 
 (defn- get-key-decoder [arg1 arg2]

--- a/src/me/vedang/clj_fdb/internal/util.clj
+++ b/src/me/vedang/clj_fdb/internal/util.clj
@@ -1,7 +1,8 @@
 (ns me.vedang.clj-fdb.internal.util
-  (:require [me.vedang.clj-fdb.core :as fc]
+  (:require [me.vedang.clj-fdb.FDB :as cfdb]
+            [me.vedang.clj-fdb.core :as fc]
             [me.vedang.clj-fdb.directory.directory :as fdir]
-            [me.vedang.clj-fdb.FDB :as cfdb]
+            [me.vedang.clj-fdb.range :as frange]
             [me.vedang.clj-fdb.tuple.tuple :as ftup])
   (:import com.apple.foundationdb.Database))
 
@@ -34,3 +35,11 @@
     (binding [*test-prefix* random-prefix]
       (test))
     (clear-all-with-prefix random-prefix)))
+
+(def ^:private smallest-ba (byte-array [(unchecked-byte 0x01)]))
+(def ^:private largest-ba (byte-array [(unchecked-byte 0xff)]))
+
+(defn clear-db
+  "WARNING! This clears the entire db."
+  [db]
+  (fc/clear-range db (frange/range smallest-ba largest-ba)))

--- a/src/me/vedang/clj_fdb/subspace/subspace.clj
+++ b/src/me/vedang/clj_fdb/subspace/subspace.clj
@@ -5,10 +5,13 @@
            com.apple.foundationdb.subspace.Subspace
            com.apple.foundationdb.tuple.Tuple))
 
+(def ^:private byte-array-class (class (byte-array 0)))
+
 (defn ^Subspace create
   "Constructor for a subspace formed with the specified prefix Tuple."
   ([prefix]
    (cond
+     (instance? byte-array-class prefix) (Subspace. prefix)
      (vector? prefix) (Subspace. (ftup/create prefix))
      (instance? Tuple prefix) (Subspace. ^Tuple prefix)
      :else (throw (IllegalArgumentException.
@@ -41,11 +44,12 @@
   suffix."
   ([^Subspace s]
    (.pack s))
-  ([^Subspace s t]
+  ([^Subspace s k]
    (cond
-     (instance? Tuple t) (.pack s ^Tuple t)
-     (vector? t) (.pack s ^Tuple (ftup/create t))
-     :else (.pack s ^Tuple (ftup/from t)))))
+     (instance? byte-array-class k) (.pack s k)
+     (instance? Tuple k) (.pack s ^Tuple k)
+     (vector? k) (.pack s ^Tuple (ftup/create k))
+     :else (.pack s ^Tuple (ftup/from k)))))
 
 
 (defn ^Tuple unpack

--- a/src/me/vedang/clj_fdb/subspace/subspace.clj
+++ b/src/me/vedang/clj_fdb/subspace/subspace.clj
@@ -5,13 +5,10 @@
            com.apple.foundationdb.subspace.Subspace
            com.apple.foundationdb.tuple.Tuple))
 
-(def ^:private byte-array-class (class (byte-array 0)))
-
 (defn ^Subspace create
   "Constructor for a subspace formed with the specified prefix Tuple."
   ([prefix]
    (cond
-     (instance? byte-array-class prefix) (Subspace. prefix)
      (vector? prefix) (Subspace. (ftup/create prefix))
      (instance? Tuple prefix) (Subspace. ^Tuple prefix)
      :else (throw (IllegalArgumentException.
@@ -44,12 +41,11 @@
   suffix."
   ([^Subspace s]
    (.pack s))
-  ([^Subspace s k]
+  ([^Subspace s t]
    (cond
-     (instance? byte-array-class k) (.pack s k)
-     (instance? Tuple k) (.pack s ^Tuple k)
-     (vector? k) (.pack s ^Tuple (ftup/create k))
-     :else (.pack s ^Tuple (ftup/from k)))))
+     (instance? Tuple t) (.pack s ^Tuple t)
+     (vector? t) (.pack s ^Tuple (ftup/create t))
+     :else (.pack s ^Tuple (ftup/from t)))))
 
 
 (defn ^Tuple unpack

--- a/src/me/vedang/clj_fdb/transaction.clj
+++ b/src/me/vedang/clj_fdb/transaction.clj
@@ -1,7 +1,7 @@
 (ns me.vedang.clj-fdb.transaction
   (:refer-clojure :exclude [get set read])
   (:import clojure.lang.IFn
-           [com.apple.foundationdb MutationType Range Transaction TransactionContext]
+           [com.apple.foundationdb MutationType KeySelector Range Transaction TransactionContext]
            com.apple.foundationdb.async.AsyncIterable
            java.util.concurrent.CompletableFuture
            [java.util.function Function Supplier]))
@@ -89,9 +89,16 @@
   "Gets an ordered range of keys and values from the database. The
   begin and end keys are specified by byte[] arrays, with the begin
   key inclusive and the end key exclusive. Ranges are returned from
-  calls to Tuple.range() and Range.startsWith(byte[])."
-  [^Transaction tr ^Range rg]
-  (.getRange tr rg))
+  calls to Tuple.range(), Range.startsWith(byte[]) or can be constructed
+  explicitly. The other option is to use KeySelectors to specify the
+  beginning and end of a Range to return."
+  {:arglists '([tc rnge] [tc rnge limit] [tc begin end] [tc begin end limit])}
+  ([^Transaction tr ^Range rg]
+   (.getRange tr rg))
+  ([^Transaction tr arg1 arg2]
+   (.getRange tr arg1 arg2))
+  ([^Transaction tr ^KeySelector begin ^KeySelector end limit]
+   (.getRange tr begin end limit)))
 
 
 (defn clear-key

--- a/test/me/vedang/clj_fdb/core_test.clj
+++ b/test/me/vedang/clj_fdb/core_test.clj
@@ -5,7 +5,7 @@
             [me.vedang.clj-fdb.core :as fc]
             [me.vedang.clj-fdb.directory.directory :as fdir]
             [me.vedang.clj-fdb.internal.util :as u]
-            [me.vedang.clj-fdb.key-selector :as sut]
+            [me.vedang.clj-fdb.key-selector :as fks]
             [me.vedang.clj-fdb.range :as frange]
             [me.vedang.clj-fdb.subspace.subspace :as fsub]
             [me.vedang.clj-fdb.transaction :as ftr]
@@ -138,28 +138,28 @@
       (testing "get-range with keyselectors"
         (is (=  (zipmap (take 6 input-keys) (repeat v))
                 (fc/get-range db
-                              (sut/first-greater-or-equal (fsub/pack subspace (ftup/from "foo")))
-                              (sut/first-greater-or-equal (fsub/pack subspace (ftup/from "foo5")))
+                              (fks/first-greater-or-equal (fsub/pack subspace (ftup/from "foo")))
+                              (fks/first-greater-or-equal (fsub/pack subspace (ftup/from "foo5")))
                               {:keyfn third :valfn bs/to-string}))))
 
       (testing "get-range with keyselectors and limit"
         (is (= {"foo" v "foo0" v}
                (fc/get-range db
-                             (sut/first-greater-or-equal (fsub/pack subspace (ftup/from "foo")))
-                             (sut/first-greater-or-equal (fsub/pack subspace (ftup/from "foo5")))
+                             (fks/first-greater-or-equal (fsub/pack subspace (ftup/from "foo")))
+                             (fks/first-greater-or-equal (fsub/pack subspace (ftup/from "foo5")))
                              {:keyfn third :valfn bs/to-string :limit 2}))))
 
       (testing "get-range with keyselectors and limit and skip"
         (is (= {"foo1" v "foo2" v}
                (fc/get-range db
-                             (sut/first-greater-or-equal (fsub/pack subspace (ftup/from "foo")))
-                             (sut/first-greater-or-equal (fsub/pack subspace (ftup/from "foo5")))
+                             (fks/first-greater-or-equal (fsub/pack subspace (ftup/from "foo")))
+                             (fks/first-greater-or-equal (fsub/pack subspace (ftup/from "foo5")))
                              {:keyfn third :valfn bs/to-string :limit 2 :skip 2})))
         ;; case where skip goes beyond end keyselector
         (is (= {"foo4" v }
                (fc/get-range db
-                             (sut/first-greater-or-equal (fsub/pack subspace (ftup/from "foo")))
-                             (sut/first-greater-or-equal (fsub/pack subspace (ftup/from "foo5")))
+                             (fks/first-greater-or-equal (fsub/pack subspace (ftup/from "foo")))
+                             (fks/first-greater-or-equal (fsub/pack subspace (ftup/from "foo5")))
                              {:keyfn third :valfn bs/to-string :limit 2 :skip 5})))))))
 
 (deftest clear-range-tests

--- a/test/me/vedang/clj_fdb/key_selector_test.clj
+++ b/test/me/vedang/clj_fdb/key_selector_test.clj
@@ -1,34 +1,34 @@
 (ns me.vedang.clj-fdb.key-selector-test
   (:require
-    [byte-streams :as bs]
-    [clojure.test :refer [deftest is testing]]
-    [me.vedang.clj-fdb.key-selector :as sut]))
+   [byte-streams :as bs]
+   [clojure.test :refer [deftest is testing]]
+   [me.vedang.clj-fdb.key-selector :as fks]))
 
 
 (deftest constructors-and-getters-tests
   (testing "Test getter functions for key-selectors"
     (let [key-selectors-and-expected-results
-          [{:ks (sut/last-less-than (.getBytes "A"))
+          [{:ks (fks/last-less-than (.getBytes "A"))
             :key "A"
             :offset 0}
-           {:ks (sut/last-less-or-equal (.getBytes "B"))
+           {:ks (fks/last-less-or-equal (.getBytes "B"))
             :key "B"
             :offset 0}
-           {:ks (sut/first-greater-than (.getBytes "C"))
+           {:ks (fks/first-greater-than (.getBytes "C"))
             :key "C"
             :offset 1}
-           {:ks (sut/first-greater-or-equal (.getBytes "D"))
+           {:ks (fks/first-greater-or-equal (.getBytes "D"))
             :key "D"
             :offset 1}]]
       (doseq [ks key-selectors-and-expected-results]
-        (is (=  (:key ks) (bs/to-string (sut/get-key (:ks ks))))
-            (=  (:offset ks) (sut/get-offset (:ks ks))))))))
+        (is (=  (:key ks) (bs/to-string (fks/get-key (:ks ks))))
+            (=  (:offset ks) (fks/get-offset (:ks ks))))))))
 
 
 (deftest add-offset-to-key-selectors-tests
-  (let [ks-1 (sut/last-less-than (.getBytes "A"))
-        new-ks-1 (sut/add ks-1 10)
-        ks-2 (sut/first-greater-than (.getBytes "A"))
-        new-ks-2 (sut/add ks-2 -5)]
-    (is (=  10 (sut/get-offset new-ks-1))
-        (=  -4 (sut/get-offset new-ks-2)))))
+  (let [ks-1 (fks/last-less-than (.getBytes "A"))
+        new-ks-1 (fks/add ks-1 10)
+        ks-2 (fks/first-greater-than (.getBytes "A"))
+        new-ks-2 (fks/add ks-2 -5)]
+    (is (=  10 (fks/get-offset new-ks-1))
+        (=  -4 (fks/get-offset new-ks-2)))))


### PR DESCRIPTION
- `get-range` also supports limit and skip now.
- bumping the deps to 6.3.23
- adding deps.edn to support git deps
-~a couple of tweaks to better support raw byte keys~

So here the first PR for the issues raised in #29. It essentially adds KeySelectors and `limit`/`skip` options to `get-range`.
I am not sure this is is the best approach as this immense overloading of `get-range` makes the code a bit messy. So maybe worth thinking if a second `get-range` function would be a better option.

Will follow up with a second PR concerning the ordering returned by get-range.