### PR TITLE
Make accumulator for get-range configurable

### DIFF
--- a/src/me/vedang/clj_fdb/core.clj
+++ b/src/me/vedang/clj_fdb/core.clj
@@ -112,7 +112,6 @@
        (fsub/range s t))
      (range arg2))))
 
-
 (defn get-range
   "Takes the following:
   - TransactionContext `tc`
@@ -123,6 +122,8 @@
   The `opts` map takes the following option at the moment:
   - `keyfn` :
   - `valfn` : Functions to transform the key/value to the correct format.
+  - `coll` : A collection of the type into which the result should be
+  accumulated.
 
   Note that the byte-arrays are always sent through the `fimpl/decode`
   function first. (So if you have stored a Tuple in FDB, the `valfn`
@@ -146,16 +147,16 @@
                        (partial fimpl/decode (or s k))
                        fimpl/decode)
          keyfn (comp (:keyfn opts identity) key-decoder)
-         valfn (comp (:valfn opts identity) fimpl/decode)]
+         valfn (comp (:valfn opts identity) fimpl/decode)
+         empty-coll (or (empty (:coll opts)) {})]
      (ftr/read tc
                (fn [^Transaction tr]
-                 (reduce (fn [acc ^KeyValue kv]
-                           (assoc acc
-                                  (keyfn (.getKey kv))
-                                  (valfn (.getValue kv))))
-                         {}
-                         (ftr/get-range tr rg)))))))
-
+                 (-> (reduce (fn [acc ^KeyValue kv]
+                               (conj! acc [(keyfn (.getKey kv))
+                                           (valfn (.getValue kv))]))
+                             (transient empty-coll)
+                             (ftr/get-range tr rg))
+                     persistent!))))))
 
 (defn clear-range
   "Takes the following:

--- a/src/me/vedang/clj_fdb/core.clj
+++ b/src/me/vedang/clj_fdb/core.clj
@@ -151,12 +151,12 @@
          empty-coll (or (empty (:coll opts)) {})]
      (ftr/read tc
                (fn [^Transaction tr]
-                 (-> (reduce (fn [acc ^KeyValue kv]
-                               (conj! acc [(keyfn (.getKey kv))
-                                           (valfn (.getValue kv))]))
-                             (transient empty-coll)
-                             (ftr/get-range tr rg))
-                     persistent!))))))
+                 (persistent!
+                  (reduce (fn [acc ^KeyValue kv]
+                            (conj! acc [(keyfn (.getKey kv))
+                                        (valfn (.getValue kv))]))
+                          (transient empty-coll)
+                          (ftr/get-range tr rg))))))))
 
 (defn clear-range
   "Takes the following:

--- a/test/me/vedang/clj_fdb/core_test.clj
+++ b/test/me/vedang/clj_fdb/core_test.clj
@@ -61,6 +61,24 @@
         (is (= expected-map
                (fc/get-range db rg {:keyfn second :valfn bs/to-string})))))))
 
+(deftest get-range-accumulator-test
+  (testing "Test the best-case path for `fc/get-range`. End is exclusive."
+    (let [input-keys ["bar" "car" "foo" "gum"]
+          begin      (ftup/pack (ftup/from u/*test-prefix* "b"))
+          end        (ftup/pack (ftup/from u/*test-prefix* "g"))
+          rg         (frange/range begin end)
+          v          "1"
+          expected-vec [["bar" v] ["car" v] ["foo" v]]]
+      (with-open [^Database db (cfdb/open fdb)]
+        (ftr/run db
+          (fn [^Transaction tr]
+            (doseq [k input-keys]
+              (let [k (ftup/from u/*test-prefix* k)]
+                (fc/set tr k (bs/to-byte-array v))))))
+
+        (is (= expected-vec
+               (fc/get-range db rg {:keyfn second :valfn bs/to-string :coll []})))))))
+
 
 (deftest clear-range-tests
   (testing "Test the best-case path for `fc/clear-range`. End is exclusive."


### PR DESCRIPTION
This is how I would add a custom accumulator to `get-range`. 

I would not use something like a `flatland/map` as you mentioned in #29. I would even consider making `get-range` always return a sequential structure by default (which breaks downstream but I don't know if that is an issue for you). We can discuss more how you think it is best approached.